### PR TITLE
[Feat/#3] 회원 관련 기본 CRUD 기능 구현

### DIFF
--- a/src/main/java/com/airbnb/AirbnbApplication.java
+++ b/src/main/java/com/airbnb/AirbnbApplication.java
@@ -2,8 +2,10 @@ package com.airbnb;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class AirbnbApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/airbnb/domain/accommodation/Accommodation.java
+++ b/src/main/java/com/airbnb/domain/accommodation/Accommodation.java
@@ -3,7 +3,7 @@ package com.airbnb.domain.accommodation;
 import com.airbnb.domain.accommodationDiscount.AccommodationDiscount;
 import com.airbnb.domain.common.Address;
 import com.airbnb.domain.common.BaseTime;
-import com.airbnb.domain.member.Member;
+import com.airbnb.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/src/main/java/com/airbnb/domain/booking/Booking.java
+++ b/src/main/java/com/airbnb/domain/booking/Booking.java
@@ -2,7 +2,7 @@ package com.airbnb.domain.booking;
 
 import com.airbnb.domain.accommodation.Accommodation;
 import com.airbnb.domain.common.BaseTime;
-import com.airbnb.domain.member.Member;
+import com.airbnb.domain.member.entity.Member;
 import com.airbnb.domain.payment.Payment;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/airbnb/domain/common/LoginType.java
+++ b/src/main/java/com/airbnb/domain/common/LoginType.java
@@ -1,5 +1,5 @@
 package com.airbnb.domain.common;
 
 public enum LoginType {
-    KAKAO, GITHUB, NAVER, GOOGLE, EMAIL
+    KAKAO, GITHUB, NAVER, GOOGLE, DEFALUT
 }

--- a/src/main/java/com/airbnb/domain/like/Like.java
+++ b/src/main/java/com/airbnb/domain/like/Like.java
@@ -1,7 +1,7 @@
 package com.airbnb.domain.like;
 
 import com.airbnb.domain.accommodation.Accommodation;
-import com.airbnb.domain.member.Member;
+import com.airbnb.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/com/airbnb/domain/member/controller/MemberController.java
+++ b/src/main/java/com/airbnb/domain/member/controller/MemberController.java
@@ -3,9 +3,12 @@ package com.airbnb.domain.member.controller;
 import com.airbnb.domain.member.dto.request.SignUpRequest;
 import com.airbnb.domain.member.dto.response.MemberResponse;
 import com.airbnb.domain.member.service.MemberService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,5 +25,17 @@ public class MemberController {
     public ResponseEntity<MemberResponse> signUp(@Validated @RequestBody SignUpRequest signUpRequest) {
         MemberResponse createdMember = memberService.signUp(signUpRequest);
         return ResponseEntity.ok(createdMember);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<MemberResponse>> getAll() {
+        List<MemberResponse> allMembers = memberService.getAll();
+        return ResponseEntity.ok(allMembers);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<MemberResponse> getById(@PathVariable Long id) {
+        MemberResponse targetMember = memberService.getById(id);
+        return ResponseEntity.ok(targetMember);
     }
 }

--- a/src/main/java/com/airbnb/domain/member/controller/MemberController.java
+++ b/src/main/java/com/airbnb/domain/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.airbnb.domain.member.controller;
 
 import com.airbnb.domain.member.dto.request.SignUpRequest;
+import com.airbnb.domain.member.dto.request.UpdateMemberRequest;
 import com.airbnb.domain.member.dto.response.MemberResponse;
 import com.airbnb.domain.member.service.MemberService;
 import java.util.List;
@@ -10,6 +11,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -37,5 +39,12 @@ public class MemberController {
     public ResponseEntity<MemberResponse> getById(@PathVariable Long id) {
         MemberResponse targetMember = memberService.getById(id);
         return ResponseEntity.ok(targetMember);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<MemberResponse> updateById(@PathVariable Long id,
+        @RequestBody @Validated UpdateMemberRequest updateRequest) {
+        MemberResponse updatedMember = memberService.update(id, updateRequest);
+        return ResponseEntity.ok(updatedMember);
     }
 }

--- a/src/main/java/com/airbnb/domain/member/controller/MemberController.java
+++ b/src/main/java/com/airbnb/domain/member/controller/MemberController.java
@@ -8,6 +8,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -46,5 +47,11 @@ public class MemberController {
         @RequestBody @Validated UpdateMemberRequest updateRequest) {
         MemberResponse updatedMember = memberService.update(id, updateRequest);
         return ResponseEntity.ok(updatedMember);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteById(@PathVariable Long id) {
+        memberService.delete(id);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/airbnb/domain/member/controller/MemberController.java
+++ b/src/main/java/com/airbnb/domain/member/controller/MemberController.java
@@ -1,0 +1,26 @@
+package com.airbnb.domain.member.controller;
+
+import com.airbnb.domain.member.dto.request.SignUpRequest;
+import com.airbnb.domain.member.dto.response.MemberResponse;
+import com.airbnb.domain.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/members")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping
+    public ResponseEntity<MemberResponse> signUp(@Validated @RequestBody SignUpRequest signUpRequest) {
+        MemberResponse createdMember = memberService.signUp(signUpRequest);
+        return ResponseEntity.ok(createdMember);
+    }
+}

--- a/src/main/java/com/airbnb/domain/member/dto/request/SignUpRequest.java
+++ b/src/main/java/com/airbnb/domain/member/dto/request/SignUpRequest.java
@@ -1,0 +1,62 @@
+package com.airbnb.domain.member.dto.request;
+
+import com.airbnb.domain.common.LoginType;
+import com.airbnb.domain.common.Role;
+import com.airbnb.domain.member.entity.Member;
+import com.airbnb.global.security.PasswordEncoder;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import java.util.ArrayList;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class SignUpRequest {
+
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Email(regexp = "[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?")
+    private String email;
+
+    @NotBlank(message = "사용자 이름을 입력해주세요.")
+    @Size(min = 3, max = 20, message = "사용자 이름은 3자 이상 20자 이하이어야 합니다.")
+    @Pattern(regexp = "^[a-zA-Z가-힣\\s]{3,20}$", message = "사용자 이름 형식이 올바르지 않습니다.")  // 한글 또는 영문 구성
+    private String name;
+    private String imgUrl;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하이어야 합니다.")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,20}$", // 숫자, 영문, 특수문자 1개 이상 포함
+        message = "비밀번호 형식이 올바르지 않습니다.")
+    private String password;
+
+    @NotBlank(message = "비밀번호를 다시 입력해주세요.")
+    @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하이어야 합니다.")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,20}$",
+        message = "비밀번호 형식이 올바르지 않습니다.")
+    private String confirmPassword;
+
+    @NotBlank(message = "은행을 선택해주세요.")
+    private String bankName;
+
+    @NotBlank(message = "계좌번호를 입력해주세요.")
+    private String accountNumber;
+
+    public Member toEntity(PasswordEncoder passwordEncoder) {
+        return Member.builder()
+            .email(email)
+            .loginType(LoginType.DEFALUT) // 일반 email 로그인
+            .roles(new ArrayList<>(Role.GUEST.ordinal())) // 게스트(default) 권한 부여
+            .name(name)
+            .imgUrl(imgUrl)
+            .encodedPassword(passwordEncoder.encode(password))
+            .bankName(bankName)
+            .accountNumber(accountNumber)
+            .build();
+    }
+}

--- a/src/main/java/com/airbnb/domain/member/dto/request/UpdateMemberRequest.java
+++ b/src/main/java/com/airbnb/domain/member/dto/request/UpdateMemberRequest.java
@@ -1,0 +1,39 @@
+package com.airbnb.domain.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class UpdateMemberRequest {
+
+    @NotBlank(message = "사용자 이름을 입력해주세요.")
+    @Size(min = 3, max = 20, message = "사용자 이름은 3자 이상 20자 이하이어야 합니다.")
+    @Pattern(regexp = "^[a-zA-Z가-힣\\s]{3,20}$", message = "사용자 이름 형식이 올바르지 않습니다.")
+    private String name;
+    private String imgUrl;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하이어야 합니다.")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,20}$",
+        message = "비밀번호 형식이 올바르지 않습니다.")
+    private String password;
+
+    @NotBlank(message = "비밀번호를 다시 입력해주세요.")
+    @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하이어야 합니다.")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,20}$",
+        message = "비밀번호 형식이 올바르지 않습니다.")
+    private String confirmPassword;
+
+    @NotBlank(message = "은행을 선택해주세요.")
+    private String bankName;
+
+    @NotBlank(message = "계좌번호를 입력해주세요.")
+    private String accountNumber;
+}

--- a/src/main/java/com/airbnb/domain/member/dto/response/MemberResponse.java
+++ b/src/main/java/com/airbnb/domain/member/dto/response/MemberResponse.java
@@ -1,0 +1,24 @@
+package com.airbnb.domain.member.dto.response;
+
+import com.airbnb.domain.member.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MemberResponse {
+
+    private String email;
+    private String imgUrl;
+    private String name;
+
+    public static MemberResponse of(Member member) {
+        return MemberResponse.builder()
+            .email(member.getEmail())
+            .name(member.getName())
+            .imgUrl(member.getImgUrl())
+            .build();
+    }
+}

--- a/src/main/java/com/airbnb/domain/member/entity/Member.java
+++ b/src/main/java/com/airbnb/domain/member/entity/Member.java
@@ -3,7 +3,9 @@ package com.airbnb.domain.member.entity;
 import com.airbnb.domain.common.BaseTime;
 import com.airbnb.domain.common.LoginType;
 import com.airbnb.domain.common.Role;
+import com.airbnb.domain.member.dto.request.UpdateMemberRequest;
 import com.airbnb.domain.member.entity.bankAccount.BankType;
+import com.airbnb.global.security.PasswordEncoder;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDateTime;
@@ -59,5 +61,14 @@ public class Member extends BaseTime {
         this.encodedPassword = encodedPassword;
         this.accountBank = BankType.of(bankName);
         this.accountNumber = accountNumber;
+    }
+
+    public Member update(UpdateMemberRequest updateRequest, PasswordEncoder passwordEncoder) {
+        this.name = updateRequest.getName();
+        this.imgUrl = updateRequest.getImgUrl();
+        this.encodedPassword = passwordEncoder.encode(updateRequest.getPassword());
+        this.accountBank = BankType.of(updateRequest.getBankName());
+        this.accountNumber = updateRequest.getAccountNumber();
+        return this;
     }
 }

--- a/src/main/java/com/airbnb/domain/member/entity/Member.java
+++ b/src/main/java/com/airbnb/domain/member/entity/Member.java
@@ -16,6 +16,8 @@ import org.hibernate.annotations.Where;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE member SET deleted_at = NOW() WHERE member_id = ?")
+@Where(clause = "deleted_at IS NULL")
 public class Member extends BaseTime {
 
     @Id

--- a/src/main/java/com/airbnb/domain/member/entity/Member.java
+++ b/src/main/java/com/airbnb/domain/member/entity/Member.java
@@ -1,13 +1,15 @@
-package com.airbnb.domain.member;
+package com.airbnb.domain.member.entity;
 
 import com.airbnb.domain.common.BaseTime;
 import com.airbnb.domain.common.LoginType;
 import com.airbnb.domain.common.Role;
+import com.airbnb.domain.member.entity.bankAccount.BankType;
 import jakarta.persistence.*;
 import lombok.*;
-
 import java.time.LocalDateTime;
 import java.util.List;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Getter
@@ -24,7 +26,7 @@ public class Member extends BaseTime {
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
-    private LoginType loginType;    // default email
+    private LoginType loginType;
 
     @ElementCollection(fetch = FetchType.EAGER) // TODO: LAZY로 할지 고민해보기
     @Enumerated(EnumType.STRING)
@@ -35,13 +37,19 @@ public class Member extends BaseTime {
     private String imgUrl;
     private String refreshToken;
 
-    @Column(nullable = false)
+    @Column(name = "password", nullable = false)
     private String encodedPassword;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private BankType accountBank;
+
+    @Column(nullable = false)
     private String accountNumber;
     private LocalDateTime deletedAt;
 
     @Builder
-    private Member(String email, LoginType loginType, List<Role> roles, String name, String imgUrl, String refreshToken, String encodedPassword, String accountNumber) {
+    private Member(String email, LoginType loginType, List<Role> roles, String name, String imgUrl, String refreshToken, String encodedPassword, String bankName, String accountNumber) {
         this.email = email;
         this.loginType = loginType;
         this.roles = roles;
@@ -49,6 +57,7 @@ public class Member extends BaseTime {
         this.imgUrl = imgUrl;
         this.refreshToken = refreshToken;
         this.encodedPassword = encodedPassword;
+        this.accountBank = BankType.of(bankName);
         this.accountNumber = accountNumber;
     }
 }

--- a/src/main/java/com/airbnb/domain/member/entity/bankAccount/BankAccount.java
+++ b/src/main/java/com/airbnb/domain/member/entity/bankAccount/BankAccount.java
@@ -1,0 +1,15 @@
+package com.airbnb.domain.member.entity.bankAccount;
+
+import lombok.Getter;
+
+@Getter
+public class BankAccount {
+
+    private final BankType type;
+    private final String number;
+
+    public BankAccount(String bankName, String number) {
+        this.type = BankType.of(bankName);
+        this.number = number;
+    }
+}

--- a/src/main/java/com/airbnb/domain/member/entity/bankAccount/BankType.java
+++ b/src/main/java/com/airbnb/domain/member/entity/bankAccount/BankType.java
@@ -1,0 +1,37 @@
+package com.airbnb.domain.member.entity.bankAccount;
+
+import java.util.Arrays;
+import lombok.Getter;
+
+@Getter
+public enum BankType {
+    KAKAO("카카오뱅크"),
+    KB("국민은행"),
+    IBK("기업은행"),
+    SHINHAN("신한은행"),
+    NH("농협은행"),
+    KDB("산업은행"),
+    WOORI("우리은행"),
+    CITY("한국씨티은행"),
+    HANA("하나은행"),
+    SC("SC제일은행"),
+    BNK("부산은행"),
+    KFCC("새마을금고"),
+    SH("수협은행"),
+    KBANK("케이뱅크"),
+    TOSS("토스뱅크"),
+    ;
+
+    private final String korean;
+
+    BankType(String korean) {
+        this.korean = korean;
+    }
+
+    public static BankType of(String korean) {
+        return Arrays.stream(BankType.values())
+            .filter(bankType -> bankType.korean.equals(korean))
+            .findAny()
+            .orElseThrow();
+    }
+}

--- a/src/main/java/com/airbnb/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/airbnb/domain/member/repository/MemberRepository.java
@@ -1,0 +1,16 @@
+package com.airbnb.domain.member.repository;
+
+import com.airbnb.domain.member.entity.Member;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    boolean existsByEmail(String email);
+    Optional<Member> findByEmail(String email);
+
+}

--- a/src/main/java/com/airbnb/domain/member/service/MemberService.java
+++ b/src/main/java/com/airbnb/domain/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.airbnb.domain.member.service;
 
 import com.airbnb.domain.member.dto.request.SignUpRequest;
+import com.airbnb.domain.member.dto.request.UpdateMemberRequest;
 import com.airbnb.domain.member.dto.response.MemberResponse;
 import com.airbnb.domain.member.entity.Member;
 import com.airbnb.domain.member.repository.MemberRepository;
@@ -47,6 +48,18 @@ public class MemberService {
             .orElseThrow(() -> new IllegalArgumentException("회원정보가 없습니다."));
 
         return MemberResponse.of(targetMember);
+    }
+
+    @Transactional
+    public MemberResponse update(Long targetId, UpdateMemberRequest updateRequest) throws IllegalArgumentException {
+        Member targetMember = memberRepository.findById(targetId)
+            .orElseThrow(() -> new IllegalArgumentException("회원정보가 없습니다."));
+        if (!isPasswordConfirmed(updateRequest.getPassword(), updateRequest.getConfirmPassword())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        Member updatedMember = targetMember.update(updateRequest, passwordEncoder);
+        return MemberResponse.of(updatedMember);
     }
 
     private boolean isPasswordConfirmed(String password, String confirmPassword) {

--- a/src/main/java/com/airbnb/domain/member/service/MemberService.java
+++ b/src/main/java/com/airbnb/domain/member/service/MemberService.java
@@ -1,0 +1,35 @@
+package com.airbnb.domain.member.service;
+
+import com.airbnb.domain.member.dto.request.SignUpRequest;
+import com.airbnb.domain.member.dto.response.MemberResponse;
+import com.airbnb.domain.member.entity.Member;
+import com.airbnb.domain.member.repository.MemberRepository;
+import com.airbnb.global.security.PasswordEncoder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public MemberResponse signUp(SignUpRequest signUpRequest) throws IllegalArgumentException {
+        if (memberRepository.existsByEmail(signUpRequest.getEmail())) {
+            throw new IllegalArgumentException("동일한 이메일이 이미 존재합니다.");
+        }
+        if (!isPasswordConfirmed(signUpRequest.getPassword(), signUpRequest.getConfirmPassword())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        Member savedMember = memberRepository.save(signUpRequest.toEntity(passwordEncoder));
+        return MemberResponse.of(savedMember);
+    }
+
+    private boolean isPasswordConfirmed(String password, String confirmPassword) {
+        return password.equals(confirmPassword);
+    }
+}

--- a/src/main/java/com/airbnb/domain/member/service/MemberService.java
+++ b/src/main/java/com/airbnb/domain/member/service/MemberService.java
@@ -5,6 +5,7 @@ import com.airbnb.domain.member.dto.response.MemberResponse;
 import com.airbnb.domain.member.entity.Member;
 import com.airbnb.domain.member.repository.MemberRepository;
 import com.airbnb.global.security.PasswordEncoder;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,6 +28,25 @@ public class MemberService {
 
         Member savedMember = memberRepository.save(signUpRequest.toEntity(passwordEncoder));
         return MemberResponse.of(savedMember);
+    }
+
+    public List<MemberResponse> getAll() {
+        List<Member> allMembers = memberRepository.findAll();
+        return allMembers.stream().map(MemberResponse::of).toList();
+    }
+
+    public MemberResponse getById(Long targetId) throws IllegalArgumentException {
+        Member targetMember = memberRepository.findById(targetId)
+            .orElseThrow(() -> new IllegalArgumentException("회원정보가 없습니다."));
+
+        return MemberResponse.of(targetMember);
+    }
+
+    public MemberResponse getByEmail(String email) throws IllegalArgumentException {
+        Member targetMember = memberRepository.findByEmail(email)
+            .orElseThrow(() -> new IllegalArgumentException("회원정보가 없습니다."));
+
+        return MemberResponse.of(targetMember);
     }
 
     private boolean isPasswordConfirmed(String password, String confirmPassword) {

--- a/src/main/java/com/airbnb/domain/member/service/MemberService.java
+++ b/src/main/java/com/airbnb/domain/member/service/MemberService.java
@@ -62,6 +62,11 @@ public class MemberService {
         return MemberResponse.of(updatedMember);
     }
 
+    @Transactional
+    public void delete(Long targetId) throws IllegalArgumentException {
+        memberRepository.deleteById(targetId);
+    }
+
     private boolean isPasswordConfirmed(String password, String confirmPassword) {
         return password.equals(confirmPassword);
     }

--- a/src/main/java/com/airbnb/domain/review/Review.java
+++ b/src/main/java/com/airbnb/domain/review/Review.java
@@ -2,7 +2,7 @@ package com.airbnb.domain.review;
 
 import com.airbnb.domain.accommodation.Accommodation;
 import com.airbnb.domain.common.BaseTime;
-import com.airbnb.domain.member.Member;
+import com.airbnb.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/com/airbnb/global/security/PasswordEncoder.java
+++ b/src/main/java/com/airbnb/global/security/PasswordEncoder.java
@@ -1,0 +1,93 @@
+package com.airbnb.global.security;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.KeySpec;
+import java.util.Base64;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * 비밀번호를 암호화하고, 저장된 비밀번호와 입력한 비밀번호가 같은지 확인하는 클래스
+ */
+@Component
+public class PasswordEncoder {
+
+    @Value("${pwd.encrypt.secret-key}")
+    private String SECRET_KEY;
+
+    private static final int SALT_LENGTH = 20;
+    private static final String ALGORITHM = "PBKDF2WithHmacSHA256";
+    private static final int ITERATION = 65536;
+    private static final int KEY_LENGTH = 256;
+
+    /**
+     * 비밀번호를 암호화하는 메서드
+     */
+    public String encode(CharSequence rawPassword) {
+        byte[] salt = generateSalt();
+        byte[] encoded = encode(rawPassword, salt);
+        return Base64.getEncoder().encodeToString(encoded);
+    }
+
+    /**
+     * 입력된 비밀번호를 암호화한 결과가 저장된 암호화된 비밀번호와 같은지 확인하는 메서드
+     */
+    public boolean matches(CharSequence rawPassword, String encodedPassword) {
+        byte[] digested = Base64.getDecoder().decode(encodedPassword);
+        byte[] salt = new byte[SALT_LENGTH];
+        System.arraycopy(digested, 0, salt, 0, SALT_LENGTH);
+        return MessageDigest.isEqual(digested, encode(rawPassword, salt));
+    }
+
+    /**
+     * salt로 평문 비밀번호를 암호화하는 메서드
+     */
+    private byte[] encode(CharSequence rawPassword, byte[] salt) {
+        try {
+            KeySpec spec = new PBEKeySpec(rawPassword.toString().toCharArray(),
+                concatenate(salt, SECRET_KEY.getBytes(StandardCharsets.UTF_8)),
+                ITERATION, KEY_LENGTH);
+            SecretKeyFactory factory = SecretKeyFactory.getInstance(ALGORITHM);
+
+            byte[] hash = factory.generateSecret(spec).getEncoded();
+
+            return concatenate(salt, hash);
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+            throw new IllegalStateException("해싱이 불가능합니다.", e);
+        }
+    }
+
+    /**
+     * 여러 개의 바이트 배열을 하나로 합치는 메서드
+     */
+    private byte[] concatenate(byte[]... arrays) {
+        int length = 0;
+        for (byte[] array : arrays) {
+            length += array.length;
+        }
+        byte[] newArray = new byte[length];
+        int destPos = 0;
+        for (byte[] array : arrays) {
+            System.arraycopy(array, 0, newArray, destPos, array.length);
+            destPos += array.length;
+        }
+        return newArray;
+    }
+
+    /**
+     * salt를 생성하는 메서드
+     */
+    private byte[] generateSalt() {
+        SecureRandom random = new SecureRandom();
+        byte[] salt = new byte[SALT_LENGTH];
+        random.nextBytes(salt);
+
+        return salt;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,3 +30,7 @@ logging:
   level:
     com:
       airbnb: debug
+
+pwd:
+  encrypt:
+    secret-key:


### PR DESCRIPTION
# 🚀 Pull Request

## ✍️ 구현 내용
- 회원 도메인 관련 기본 CRUD 기능을 구현했습니다.
- postman을 이용하여 테스트를 진행하였습니다.

## 🤦‍♀️ 고민 사항
- 회원 정보 유무, 비밀번호 일치 여부, 이메일 중복 검사 등에 대한 예외 처리
  - 현재 단계에서는 IllegalArgumentException 예외를 throw하는 방식으로 임시 처리하였습니다.
  - 예외 처리 방식에 대한 논의 후 변경이 필요하다고 판단될 경우, 변경 적용될 수 있습니다.

## 🎸 추가 구현 예정
- 이메일 인증
- jwt 및 oAuth 로그인

## 🐙 관련 이슈
close #3
